### PR TITLE
Fix Paths for Thunderstore/r2modman

### DIFF
--- a/Scripts/CacheManager.cs
+++ b/Scripts/CacheManager.cs
@@ -24,7 +24,7 @@ namespace OtherLoader
 
         public static void Init()
         {
-            CachePath = Application.dataPath.Replace("/h3vr_Data", "/OtherLoaderCache");
+            CachePath = Path.Combine(OtherLoader.Directory, "cache");
 
             if (!Directory.Exists(CachePath))
             {

--- a/Scripts/Loaders.cs
+++ b/Scripts/Loaders.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BepInEx;
 using UnityEngine;
 
 namespace OtherLoader
@@ -33,7 +34,7 @@ namespace OtherLoader
 
         public void LoadLegacyAssets()
         {
-            string legacyPath = Application.dataPath.Replace("/h3vr_Data", "/Deli/mods/legacy/LegacyVirtualObjects");
+            string legacyPath = Path.Combine(OtherLoader.Directory, "LegacyVirtualObjects");
 
             if (!Directory.Exists(legacyPath))
             {

--- a/Scripts/OtherLoader.cs
+++ b/Scripts/OtherLoader.cs
@@ -2,8 +2,10 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
+using BepInEx;
 using HarmonyLib;
 using BepInEx.Logging;
 using FistVR;
@@ -16,6 +18,12 @@ namespace OtherLoader
 {
     public class OtherLoader : DeliBehaviour
     {
+        private const string TS_AUTHOR = "devyndamonster";
+        private const string TS_NAME = "OtherLoader";
+        public const string R2MM_ID = TS_AUTHOR + "-" + TS_NAME;
+
+        public static string Directory { get; } = Path.Combine(Paths.PluginPath, R2MM_ID);
+        
         public static Dictionary<string, IFileHandle> BundleFiles = new Dictionary<string, IFileHandle>();
         public static Dictionary<string, string> LegacyBundles = new Dictionary<string, string>();
         private static ConfigEntry<int> MaxActiveLoadersConfig;


### PR DESCRIPTION
This adjusts the paths used for caching and legacy objects to conform with Thunderstore and r2modman.  